### PR TITLE
chore: syncing from asdf-sqlite

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -41,7 +41,7 @@ get_source() {
 
 	echo "downloading sqlite source code; url=$sqlite_url; destDir=$ASDF_DOWNLOAD_PATH"
 
-	curl --silent "$sqlite_url" --output "$ASDF_DOWNLOAD_PATH/$sqlite_tarball"
+	curl -L --silent "$sqlite_url" --output "$ASDF_DOWNLOAD_PATH/$sqlite_tarball"
 	tar -xf "$ASDF_DOWNLOAD_PATH/$sqlite_tarball" --strip-components=1 -C "$ASDF_DOWNLOAD_PATH"
 }
 

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -16,5 +16,5 @@ echoerr() {
 }
 
 get_sqlite_url() {
-	curl --silent "$SQLITE_URL/$1"
+	curl -L --silent "$SQLITE_URL/$1"
 }


### PR DESCRIPTION
### Description
Pulling in new changes from upstream (`asdf-sqlite`) to resolve installation failures due to `curl` not following HTTP redirects when fetching from sqlite's website.